### PR TITLE
Implement API to remove KV pairs from groupcache

### DIFF
--- a/groupcache-pb/protos/groupcache.proto
+++ b/groupcache-pb/protos/groupcache.proto
@@ -10,7 +10,13 @@ message GetResponse {
   optional bytes value = 1;
 }
 
+message RemoveRequest {
+  string key = 1;
+}
+
+message RemoveResponse {}
+
 service Groupcache {
-  rpc Get(GetRequest) returns (GetResponse) {
-  };
+  rpc Get(GetRequest) returns (GetResponse) {};
+  rpc Remove(RemoveRequest) returns (RemoveResponse) {};
 }

--- a/groupcache-pb/src/groupcache_pb.rs
+++ b/groupcache-pb/src/groupcache_pb.rs
@@ -10,6 +10,15 @@ pub struct GetResponse {
     #[prost(bytes = "vec", optional, tag = "1")]
     pub value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RemoveRequest {
+    #[prost(string, tag = "1")]
+    pub key: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RemoveResponse {}
 /// Generated client implementations.
 pub mod groupcache_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -111,6 +120,23 @@ pub mod groupcache_client {
                 .insert(GrpcMethod::new("groupcache_pb.Groupcache", "Get"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn remove(
+            &mut self,
+            request: impl tonic::IntoRequest<super::RemoveRequest>,
+        ) -> std::result::Result<tonic::Response<super::RemoveResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/groupcache_pb.Groupcache/Remove");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("groupcache_pb.Groupcache", "Remove"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -124,6 +150,10 @@ pub mod groupcache_server {
             &self,
             request: tonic::Request<super::GetRequest>,
         ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status>;
+        async fn remove(
+            &self,
+            request: tonic::Request<super::RemoveRequest>,
+        ) -> std::result::Result<tonic::Response<super::RemoveResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct GroupcacheServer<T: Groupcache> {
@@ -224,6 +254,45 @@ pub mod groupcache_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = GetSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/groupcache_pb.Groupcache/Remove" => {
+                    #[allow(non_camel_case_types)]
+                    struct RemoveSvc<T: Groupcache>(pub Arc<T>);
+                    impl<T: Groupcache> tonic::server::UnaryService<super::RemoveRequest> for RemoveSvc<T> {
+                        type Response = super::RemoveResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RemoveRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut =
+                                async move { <T as Groupcache>::remove(&inner, request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = RemoveSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/groupcache-pb/src/main.rs
+++ b/groupcache-pb/src/main.rs
@@ -1,14 +1,14 @@
-use anyhow::Context;
+use anyhow::anyhow;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let current_dir = std::env::current_dir()?;
-    current_dir
-        .ends_with("groupcache-pb")
-        .then_some(0)
-        .context(format!(
+    if !current_dir.ends_with("groupcache-pb") {
+        return Err(anyhow!(
             "must be run from the root of the crate, instead was {:#?}",
             current_dir
-        ))?;
+        )
+        .into());
+    }
 
     tonic_build::configure()
         .out_dir("src/")

--- a/groupcache/Cargo.toml
+++ b/groupcache/Cargo.toml
@@ -8,10 +8,10 @@ groupcache-pb = { path = "../groupcache-pb" }
 tonic = "0.10.0"
 
 hashring = "0.3.2"
-anyhow = { version = "1.0.72", features = ["backtrace"] }
+anyhow = "1.0.72"
 thiserror = "1.0.48"
 axum = "0.6.20"
-tokio = { version = "1.12.0", features = ["full"] }
+tokio = { version = "1.12.0" }
 serde = { version = "1.0.130", features = ["derive"] }
 rmp-serde = "1.1.2"
 async-trait = "0.1.72"
@@ -22,3 +22,4 @@ moka = { version = "0.12.1", features = ["future"] }
 cargo-husky = { workspace = true }
 pretty_assertions = "1.4.0"
 tokio-stream = { version = "0.1.14", features = ["net"] }
+tokio = { version = "1.12.0", features = ["time", "test-util", "rt", "macros"] }

--- a/groupcache/src/http.rs
+++ b/groupcache/src/http.rs
@@ -1,6 +1,8 @@
 use crate::{Groupcache, ValueBounds};
 use async_trait::async_trait;
-use groupcache_pb::groupcache_pb::{groupcache_server, GetRequest, GetResponse};
+use groupcache_pb::groupcache_pb::{
+    groupcache_server, GetRequest, GetResponse, RemoveRequest, RemoveResponse,
+};
 use tonic::{Request, Response, Status};
 
 #[async_trait]
@@ -18,5 +20,12 @@ impl<Value: ValueBounds> groupcache_server::Groupcache for Groupcache<Value> {
             }
             Err(err) => Err(Status::internal(err.to_string())),
         }
+    }
+
+    async fn remove(
+        &self,
+        request: Request<RemoveRequest>,
+    ) -> Result<Response<RemoveResponse>, Status> {
+        todo!()
     }
 }

--- a/groupcache/src/http.rs
+++ b/groupcache/src/http.rs
@@ -26,6 +26,11 @@ impl<Value: ValueBounds> groupcache_server::Groupcache for Groupcache<Value> {
         &self,
         request: Request<RemoveRequest>,
     ) -> Result<Response<RemoveResponse>, Status> {
-        todo!()
+        let payload = request.into_inner();
+
+        match self.remove(&payload.key).await {
+            Ok(_) => Ok(Response::new(RemoveResponse {})),
+            Err(err) => Err(Status::internal(err.to_string())),
+        }
     }
 }

--- a/groupcache/src/lib.rs
+++ b/groupcache/src/lib.rs
@@ -23,6 +23,10 @@ impl<Value: ValueBounds> GroupcacheWrapper<Value> {
         self.0.get(key).await
     }
 
+    pub async fn remove(&self, key: &Key) -> core::result::Result<(), GroupcacheError> {
+        self.0.remove(key).await
+    }
+
     pub async fn add_peer(&self, peer: Peer) -> Result<()> {
         self.0.add_peer(peer).await
     }

--- a/groupcache/src/lib.rs
+++ b/groupcache/src/lib.rs
@@ -49,6 +49,12 @@ pub struct Peer {
     socket: SocketAddr,
 }
 
+impl Peer {
+    pub(crate) fn addr(&self) -> String {
+        format!("http://{}", self.socket.clone())
+    }
+}
+
 impl From<SocketAddr> for Peer {
     fn from(value: SocketAddr) -> Self {
         Self { socket: value }
@@ -77,7 +83,7 @@ type PeerClient = GroupcacheClient<Channel>;
 pub struct GroupcacheOptions {
     pub cache_capacity: Option<u64>,
     pub hot_cache_capacity: Option<u64>,
-    pub hot_cache_timeout_seconds: Option<Duration>,
+    pub hot_cache_ttl: Option<Duration>,
 }
 
 pub(crate) struct Options {
@@ -106,9 +112,7 @@ impl From<GroupcacheOptions> for Options {
             .hot_cache_capacity
             .unwrap_or(default.hot_cache_capacity);
 
-        let hot_cache_timeout_seconds = value
-            .hot_cache_timeout_seconds
-            .unwrap_or(default.hot_cache_ttl);
+        let hot_cache_timeout_seconds = value.hot_cache_ttl.unwrap_or(default.hot_cache_ttl);
 
         Self {
             cache_capacity,

--- a/groupcache/src/routing.rs
+++ b/groupcache/src/routing.rs
@@ -29,6 +29,8 @@ impl RoutingState {
         }
     }
 
+    // todo: I think we should instead return tuple (peer, client)
+    // this way we'd acquire reader lock only once on a hot path, not twice.
     pub(crate) fn peer_for_key(&self, key: &Key) -> Result<Peer> {
         let vnode = self.ring.get(&key).context("ring can't be empty")?;
 

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ test.sh
 - [x] Integration tests.
 - [x] Implement hot cache - caching items that are owned by different peers but are frequently loaded:
   - Not sure how I want to approach this, if I intend to implement API to removing value from groupcache.
+- [ ] Implement API to expire items from groupcache.
 - [ ] Expose timeouts as a configuration option.
 - [ ] Expose metrics from the library:
   - [ ] Struct with a bunch of atomic ints.


### PR DESCRIPTION
Eventually consistent API.

Owner of KV pair removes it from its cache. Other nodes may keep stale value until removed KV pair is evicted from hot_cache (configured by hot_cache_ttl).