### PR TITLE
Bump to axum 0.7

### DIFF
--- a/examples/kubernetes-service-discovery/Cargo.toml
+++ b/examples/kubernetes-service-discovery/Cargo.toml
@@ -10,18 +10,18 @@ publish = false
 #groupcache = { git = "https://github.com/Petroniuss/groupcache.git" }
 groupcache = { path = "../../groupcache" }
 tonic = "0.10"
-axum = "0.6"
+axum = "0.7"
 
 tower = { version = "0.4", features = ["steer"] }
-tower-http = { version = "0.4", features = ["trace"] }
-tokio = { version = "1.34", features = ["full"] }
+tower-http = { version = "0.5.0", features = ["trace"] }
+tokio = { version = "1.35", features = ["full"] }
 
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-axum-prometheus = "0.4"
+axum-prometheus = "0.5"
 
 anyhow = "1"
 async-trait = "0.1"

--- a/groupcache/Cargo.toml
+++ b/groupcache/Cargo.toml
@@ -21,8 +21,8 @@ tonic = "0.10.2"
 hashring = "0.3.3"
 anyhow = "1.0"
 thiserror = "1.0"
-axum = "0.6.20"
-tokio = { version = "1.34" }
+axum = "0.7"
+tokio = { version = "1.35" }
 serde = { version = "1.0", features = ["derive"] }
 rmp-serde = "1.1"
 async-trait = "0.1.74"
@@ -34,6 +34,6 @@ metrics = "0.21.1"
 cargo-husky = { workspace = true }
 pretty_assertions = "1.4.0"
 tokio-stream = { version = "0.1.14", features = ["net"] }
-tokio = { version = "1.34", features = ["time", "test-util", "rt", "macros"] }
+tokio = { version = "1.35", features = ["time", "test-util", "rt", "macros"] }
 rstest = "0.18.2"
 serial_test = "2.0.0"

--- a/groupcache/src/metrics.rs
+++ b/groupcache/src/metrics.rs
@@ -9,23 +9,23 @@
 //! For meaning of each metric, see below.
 
 /// Any GET request, including from peers.
-pub(crate) const METRIC_GET_TOTAL: &str = "groupcache_get_total";
+pub const METRIC_GET_TOTAL: &str = "groupcache_get_total";
 
 /// GETs that came over the network from peers.
-pub(crate) const METRIC_GET_SERVER_REQUESTS_TOTAL: &str = "groupcache_get_server_requests_total";
+pub const METRIC_GET_SERVER_REQUESTS_TOTAL: &str = "groupcache_get_server_requests_total";
 
 /// Local cache hit (without going over the network or loading a value using [crate::groupcache::ValueLoader]).
-pub(crate) const METRIC_LOCAL_CACHE_HIT_TOTAL: &str = "groupcache_local_cache_hit_total";
+pub const METRIC_LOCAL_CACHE_HIT_TOTAL: &str = "groupcache_local_cache_hit_total";
 
 /// Total calls to [`crate::groupcache::ValueLoader::load`]
-pub(crate) const METRIC_LOCAL_LOAD_TOTAL: &str = "groupcache_local_load_total";
+pub const METRIC_LOCAL_LOAD_TOTAL: &str = "groupcache_local_load_total";
 
 /// Total number of failures of [`crate::groupcache::ValueLoader::load`]
-pub(crate) const METRIC_LOCAL_LOAD_ERROR_TOTAL: &str = "groupcache_local_load_errors";
+pub const METRIC_LOCAL_LOAD_ERROR_TOTAL: &str = "groupcache_local_load_errors";
 
 /// Total number of remote GETs:
 /// - peer is not the owner and needs to make HTTP request to the owner for a given key.
-pub(crate) const METRIC_REMOTE_LOAD_TOTAL: &str = "groupcache_remote_load_total";
+pub const METRIC_REMOTE_LOAD_TOTAL: &str = "groupcache_remote_load_total";
 
 /// Total number of remote GET failures.
-pub(crate) const METRIC_REMOTE_LOAD_ERROR: &str = "groupcache_remote_load_errors";
+pub const METRIC_REMOTE_LOAD_ERROR: &str = "groupcache_remote_load_errors";


### PR DESCRIPTION
This so far is unfortunately blocked by tonic.
Will be resumed once tonic bumps its dependency on `http` crate to 1.0