### PR TITLE
misc: dependency constraints are not allowed on crates.io

### DIFF
--- a/groupcache-pb/Cargo.toml
+++ b/groupcache-pb/Cargo.toml
@@ -18,4 +18,4 @@ tonic-prost = "0.14.2"
 tonic-prost-build = { version = "0.14.2" }
 
 [build-dependencies]
-tonic-prost-build = "*"
+tonic-prost-build = { version = "0.14.2" }


### PR DESCRIPTION
Caused by:
  the remote server responded with an error (status 400 Bad Request): wildcard (`*`) dependency constraints are not allowed on crates.io. Crate 